### PR TITLE
add encoding speed test and gofmt

### DIFF
--- a/append_entries.go
+++ b/append_entries.go
@@ -19,6 +19,7 @@ type AppendEntriesRequest struct {
 // The response returned from a server appending entries to the log.
 type AppendEntriesResponse struct {
 	Term        uint64 `json:"term"`
+	Index       uint64 `json:"index"`
 	Success     bool   `json:"success"`
 	CommitIndex uint64 `json:"commitIndex"`
 }

--- a/encodingAndDecoding_test.go
+++ b/encodingAndDecoding_test.go
@@ -1,0 +1,40 @@
+package raft
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestEncodingAndDecodingSpeed(t *testing.T) {
+	entries := make([]*LogEntry, 2000)
+
+	e := newLogEntry(nil, 1, 2, &joinCommand{Name: "localhost:1000"})
+
+	for i := 0; i < 2000; i++ {
+		entries[i] = e
+	}
+
+	req := newAppendEntriesRequest(1, "leader", 1, 1, entries, 1)
+
+	var b bytes.Buffer
+
+	startTime := time.Now()
+
+	json.NewEncoder(&b).Encode(req)
+
+	fmt.Println("Encoding ", b.Len()/1000, " kb took ", time.Now().Sub(startTime))
+
+	startTime = time.Now()
+
+	resp := &AppendEntriesResponse{}
+
+	length := b.Len()
+
+	json.NewDecoder(&b).Decode(&resp)
+
+	fmt.Println("Decoding ", length/1000, " kb took ", time.Now().Sub(startTime))
+
+}

--- a/peer.go
+++ b/peer.go
@@ -91,8 +91,8 @@ func (p *Peer) startHeartbeat() {
 // Stops the peer heartbeat.
 func (p *Peer) stopHeartbeat() {
 	// here is a problem
-	// the previous stop is no buffer leader may get blocked 
-	// when heartbeat returns at line 132 
+	// the previous stop is no buffer leader may get blocked
+	// when heartbeat returns at line 132
 	// I make the channel with 1 buffer
 	// and try to panic here
 	select {

--- a/server.go
+++ b/server.go
@@ -721,7 +721,7 @@ func (s *Server) processAppendEntriesResponse(resp *AppendEntriesResponse) {
 		s.debugln("commit index ", commitIndex)
 		for i := committedIndex; i < commitIndex; i++ {
 			if entry := s.log.getEntry(i + 1); entry != nil {
-				// if the leader is a new one and the entry came from the 
+				// if the leader is a new one and the entry came from the
 				// old leader, the commit channel will be nil and no go routine
 				// is waiting from this channel
 				// if we try to send to it, the new leader will get stuck


### PR DESCRIPTION
The test encodes and decodes simple log entries. The total size is about 150kb. On my machine, it took about 40ms on average including encoding and decoding.

I am going to add an index to AE response, to help the leader decide the prevIndex of the peer.
