### PR TITLE
Fix state check in candidate inner loop.

### DIFF
--- a/server.go
+++ b/server.go
@@ -519,7 +519,6 @@ func (s *Server) candidateLoop() {
 				var err error
 				if e.target == &stopValue {
 					s.setState(Stopped)
-					break
 				} else if _, ok := e.target.(Command); ok {
 					err = NotLeaderError
 				} else if req, ok := e.target.(*AppendEntriesRequest); ok {
@@ -537,7 +536,7 @@ func (s *Server) candidateLoop() {
 
 			// both process AER and RVR can make the server to follower
 			// also break when timeout happens
-			if s.State() == Follower || timeout {
+			if s.State() != Candidate || timeout {
 				break
 			}
 		}


### PR DESCRIPTION
@xiangli-cmu I made the inner loop check for any state change since `server.go:L521` can change the state to `Stopped`. Also, I removed the `break` since it's useless in the select.
