### PR TITLE
Reset Timer on Benchmarks

### DIFF
--- a/append_entries_test.go
+++ b/append_entries_test.go
@@ -8,6 +8,7 @@ import (
 
 func BenchmarkAppendEntriesEncoding(b *testing.B) {
 	req, tmp := createTestAppendEntriesRequest(2000)
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		var buf bytes.Buffer
 		json.NewEncoder(&buf).Encode(req)
@@ -17,6 +18,7 @@ func BenchmarkAppendEntriesEncoding(b *testing.B) {
 
 func BenchmarkAppendEntriesDecoding(b *testing.B) {
 	req, buf := createTestAppendEntriesRequest(2000)
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		json.NewDecoder(bytes.NewReader(buf)).Decode(req)
 	}


### PR DESCRIPTION
@xiangli-cmu I don't think the time to encode affected the benchmark too much since it gets amortized across 50 - 100 iterations but here's the fix.
