### PR TITLE
Add Travis CI tests for go-raft.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+
+go:
+  - 1.1
+
+install:
+  - make dependencies
+

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,13 @@
+all: test
+
 coverage:
 	gocov test github.com/benbjohnson/go-raft | gocov-html > coverage.html
 	open coverage.html
+
+dependencies:
+	go get -d .
+
+test:
+	go test -v ./...
+
+.PHONY: coverage dependencies test


### PR DESCRIPTION
In playing around with the code in go-raft, I noticed that a number
of the tests are non-deterministic.  I figure Travis CI integration
will help illuminate changes that introduce regressions against
test health.

The existence of `Makefile` trips up Travis CI's default handling of Go projects, so I have added some helpers.
