### PR TITLE
feat return the stateMachine

### DIFF
--- a/server.go
+++ b/server.go
@@ -186,6 +186,11 @@ func (s *Server) Context() interface{} {
 	return s.context
 }
 
+// Retrieves the state machine passed into the constructor.
+func (s *Server) StateMachine() StateMachine {
+	return s.stateMachine
+}
+
 // Retrieves the log path for the server.
 func (s *Server) LogPath() string {
 	return path.Join(s.path, "log")


### PR DESCRIPTION
We need to expose the API to get the passed in `stateMachine`.
In `etcd`, we want to get the `store` reference from the `raft` server.
