### PR TITLE
README: benbjohnson => goraft

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ go-raft is under the MIT license.
 These projects are built on go-raft:
 
 - [coreos/etcd](https://github.com/coreos/etcd) - A highly-available key value store for shared configuration and service discovery
-- [benbjohnson/raftd](https://github.com/benbjohnson/raftd) - A reference implementation for using the go-raft library for distributed consensus.
+- [goraft/raftd](https://github.com/goraft/raftd) - A reference implementation for using the go-raft library for distributed consensus.
 - [skynetservices/skydns](https://github.com/skynetservices/skydns) - DNS for skynet or any other service discovery
 
 If you have a project that you're using go-raft in, please add it to this README so others can see implementation examples.


### PR DESCRIPTION
I guess the reference implementation lies in the "goraft" organization now, right?
