### PR TITLE
Event Dispatch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ go:
   - 1.2
 
 install:
+  - go get github.com/stretchr/testify/assert
   - make dependencies
 

--- a/event.go
+++ b/event.go
@@ -1,0 +1,55 @@
+package raft
+
+const (
+	StateChangeEventType  = "stateChange"
+	LeaderChangeEventType = "leaderChange"
+	TermChangeEventType   = "termChange"
+	AddPeerEventType      = "addPeer"
+	RemovePeerEventType   = "removePeer"
+)
+
+// Event represents an action that occurred within the Raft library.
+// Listeners can subscribe to event types by using the Server.AddEventListener() function.
+type Event interface {
+	Type() string
+	Source() interface{}
+	Value() interface{}
+	PrevValue() interface{}
+}
+
+// event is the concrete implementation of the Event interface.
+type event struct {
+	typ       string
+	source    interface{}
+	value     interface{}
+	prevValue interface{}
+}
+
+// newEvent creates a new event.
+func newEvent(typ string, value interface{}, prevValue interface{}) *event {
+	return &event{
+		typ:       typ,
+		value:     value,
+		prevValue: prevValue,
+	}
+}
+
+// Type returns the type of event that occurred.
+func (e *event) Type() string {
+	return e.typ
+}
+
+// Source returns the object that dispatched the event.
+func (e *event) Source() interface{} {
+	return e.source
+}
+
+// Value returns the current value associated with the event, if applicable.
+func (e *event) Value() interface{} {
+	return e.value
+}
+
+// PrevValue returns the previous value associated with the event, if applicable.
+func (e *event) PrevValue() interface{} {
+	return e.prevValue
+}

--- a/event_dispatcher.go
+++ b/event_dispatcher.go
@@ -1,0 +1,50 @@
+package raft
+
+import (
+	"sync"
+)
+
+// eventDispatcher is responsible for managing listeners for named events
+// and dispatching event notifications to those listeners.
+type eventDispatcher struct {
+	sync.RWMutex
+	source    interface{}
+	listeners map[string]eventListeners
+}
+
+// EventListener is a function that can receive event notifications.
+type EventListener func(Event)
+
+// EventListeners represents a collection of individual listeners.
+type eventListeners []EventListener
+
+// newEventDispatcher creates a new eventDispatcher instance.
+func newEventDispatcher(source interface{}) *eventDispatcher {
+	return &eventDispatcher{
+		source:    source,
+		listeners: make(map[string]eventListeners),
+	}
+}
+
+// AddEventListener adds a listener function for a given event type.
+func (d *eventDispatcher) AddEventListener(typ string, listener EventListener) {
+	d.Lock()
+	defer d.Unlock()
+	d.listeners[typ] = append(d.listeners[typ], listener)
+}
+
+// DispatchEvent dispatches an event.
+func (d *eventDispatcher) DispatchEvent(e Event) {
+	d.RLock()
+	defer d.RUnlock()
+
+	// Automatically set the event source.
+	if e, ok := e.(*event); ok {
+		e.source = d.source
+	}
+
+	// Dispatch the event to all listeners.
+	for _, l := range d.listeners[e.Type()] {
+		l(e)
+	}
+}

--- a/event_dispatcher_test.go
+++ b/event_dispatcher_test.go
@@ -1,0 +1,45 @@
+package raft
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Ensure that we can listen and dispatch events.
+func TestDispatchEvent(t *testing.T) {
+	var count int
+	dispatcher := newEventDispatcher(nil)
+	dispatcher.AddEventListener("foo", func(e Event) {
+		count += 1
+	})
+	dispatcher.AddEventListener("foo", func(e Event) {
+		count += 10
+	})
+	dispatcher.AddEventListener("bar", func(e Event) {
+		count += 100
+	})
+	dispatcher.DispatchEvent(&event{typ: "foo", value: nil, prevValue: nil})
+	assert.Equal(t, 11, count)
+}
+
+// Ensure that event is properly passed to listener.
+func TestEventListener(t *testing.T) {
+	dispatcher := newEventDispatcher("X")
+	dispatcher.AddEventListener("foo", func(e Event) {
+		assert.Equal(t, "foo", e.Type())
+		assert.Equal(t, "X", e.Source())
+		assert.Equal(t, 10, e.Value())
+		assert.Equal(t, 20, e.PrevValue())
+	})
+	dispatcher.DispatchEvent(&event{typ: "foo", value: 10, prevValue: 20})
+}
+
+// Benchmark the performance of event dispatch.
+func BenchmarkEventDispatch(b *testing.B) {
+	dispatcher := newEventDispatcher(nil)
+	dispatcher.AddEventListener("xxx", func(e Event) {})
+	for i := 0; i < b.N; i++ {
+		dispatcher.DispatchEvent(&event{typ: "foo", value: 10, prevValue: 20})
+	}
+}

--- a/test.go
+++ b/test.go
@@ -12,6 +12,10 @@ const (
 	testElectionTimeout  = 200 * time.Millisecond
 )
 
+const (
+	testListenerLoggerEnabled = false
+)
+
 func init() {
 	RegisterCommand(&testCommand1{})
 	RegisterCommand(&testCommand2{})
@@ -66,6 +70,15 @@ func newTestServer(name string, transporter Transporter) Server {
 		panic(err.Error())
 	}
 	server, _ := NewServer(name, p, transporter, nil, nil, "")
+	if testListenerLoggerEnabled {
+		fn := func(e Event) {
+			server := e.Source().(Server)
+			warnf("[%s] %s %v -> %v\n", server.Name(), e.Type(), e.PrevValue(), e.Value())
+		}
+		server.AddEventListener(StateChangeEventType, fn)
+		server.AddEventListener(LeaderChangeEventType, fn)
+		server.AddEventListener(TermChangeEventType, fn)
+	}
 	return server
 }
 


### PR DESCRIPTION
## Overview

This pull request includes an event dispatcher implementation that the `Server` uses. This gives applications the ability to hook into multiple event types using the observer pattern.

The `Event` includes the event type, the source of the event and the current and previous value related to the event.
## Event Types

The following event types are implemented:

```
stateChange  - Dispatched when the state changes on the server.
leaderChange - Dispatched when the leader changes on the server.
termChange   - Dispatched when the term changes on the server.
addPeer      - Dispatched when a peer is added.
removePeer   - Dispatched when a peer is removed.
```
## Server Interface Changes

Only one function is added to the `Server` interface:

``` go
func AddEventListener(typ string, func(Event))
```

There is no `RemoveEventListener()` because you can't compare functions in Go. There are ways we could get around it but I'm going to wait until we actually need to remove event listeners before implementing it.
## Notes

We can easily add more types of events but I thought this was a good first cut. I mostly want to get feedback on the approach so far.

/cc: @philips @xiangli-cmu 
