### PR TITLE
Command Context

### DIFF
--- a/command.go
+++ b/command.go
@@ -8,44 +8,31 @@ import (
 	"reflect"
 )
 
-//------------------------------------------------------------------------------
-//
-// Globals
-//
-//------------------------------------------------------------------------------
-
 var commandTypes map[string]Command
 
 func init() {
 	commandTypes = map[string]Command{}
 }
 
-//------------------------------------------------------------------------------
-//
-// Typedefs
-//
-//------------------------------------------------------------------------------
-
-// A command represents an action to be taken on the replicated state machine.
+// Command represents an action to be taken on the replicated state machine.
 type Command interface {
 	CommandName() string
-	Apply(server Server) (interface{}, error)
+}
+
+// CommandApply represents the interface to apply a command to the server.
+type CommandApply interface {
+	Apply(Context) (interface{}, error)
+}
+
+// deprecatedCommandApply represents the old interface to apply a command to the server.
+type deprecatedCommandApply interface {
+	Apply(Server) (interface{}, error)
 }
 
 type CommandEncoder interface {
 	Encode(w io.Writer) error
 	Decode(r io.Reader) error
 }
-
-//------------------------------------------------------------------------------
-//
-// Functions
-//
-//------------------------------------------------------------------------------
-
-//--------------------------------------
-// Instantiation
-//--------------------------------------
 
 // Creates a new instance of a command by name.
 func newCommand(name string, data []byte) (Command, error) {
@@ -75,10 +62,6 @@ func newCommand(name string, data []byte) (Command, error) {
 
 	return copy, nil
 }
-
-//--------------------------------------
-// Registration
-//--------------------------------------
 
 // Registers a command by storing a reference to an instance of it.
 func RegisterCommand(command Command) {

--- a/context.go
+++ b/context.go
@@ -1,0 +1,32 @@
+package raft
+
+// Context represents the current state of the server. It is passed into
+// a command when the command is being applied since the server methods
+// are locked.
+type Context interface {
+	Server() Server
+	CurrentTerm() uint64
+	CurrentIndex() uint64
+}
+
+// context is the concrete implementation of Context.
+type context struct {
+	server       Server
+	currentIndex uint64
+	currentTerm  uint64
+}
+
+// Server returns a reference to the server.
+func (c *context) Server() Server {
+	return c.server
+}
+
+// CurrentTerm returns current term the server is in.
+func (c *context) CurrentTerm() uint64 {
+	return c.currentTerm
+}
+
+// CurrentIndex returns current index the server is at.
+func (c *context) CurrentIndex() uint64 {
+	return c.currentIndex
+}


### PR DESCRIPTION
I spent the weekend trying to figure out some etcd issues after upgrading to the current Raft revision. One of the biggest issues was trying to access things like `CommitIndex()` from within a `Command.Apply()` function. The commands are executed within a server lock so it causes the app to hang when trying to retrieve the commit index from within the `Apply()` function.

The Raft version hasn't been sync'd up on etcd for a while so we should probably try to stay more in sync and hopefully these issues will pop up sooner and be easier to debug.

The change included in this PR is to pass a `Context` object to the `Apply()` function instead of the `Server` reference. I kept the old `Apply(Server)` for backwards compatibility but it's not advertised in the API anymore and it's marked as "deprecated" in the code.

The new `Context` object has `CurrentIndex()` and `CurrentTerm()` methods attached to it so the command can use that information without requiring a lock.

/cc: @philips @xiangli-cmu 
