### PR TITLE
Make HttpTranporter.Transport into an exported field

### DIFF
--- a/http_transporter.go
+++ b/http_transporter.go
@@ -24,7 +24,7 @@ type HTTPTransporter struct {
 	appendEntriesPath string
 	requestVotePath   string
 	httpClient        http.Client
-	transport         *http.Transport
+	Transport         *http.Transport
 }
 
 type HTTPMuxer interface {
@@ -44,9 +44,9 @@ func NewHTTPTransporter(prefix string) *HTTPTransporter {
 		prefix:            prefix,
 		appendEntriesPath: fmt.Sprintf("%s%s", prefix, "/appendEntries"),
 		requestVotePath:   fmt.Sprintf("%s%s", prefix, "/requestVote"),
-		transport:         &http.Transport{DisableKeepAlives: false},
+		Transport:         &http.Transport{DisableKeepAlives: false},
 	}
-	t.httpClient.Transport = t.transport
+	t.httpClient.Transport = t.Transport
 	return t
 }
 
@@ -102,7 +102,7 @@ func (t *HTTPTransporter) SendAppendEntriesRequest(server Server, peer *Peer, re
 	url := fmt.Sprintf("%s%s", peer.ConnectionString, t.AppendEntriesPath())
 	traceln(server.Name(), "POST", url)
 
-	t.transport.ResponseHeaderTimeout = server.ElectionTimeout()
+	t.Transport.ResponseHeaderTimeout = server.ElectionTimeout()
 	httpResp, err := t.httpClient.Post(url, "application/protobuf", &b)
 	if httpResp == nil || err != nil {
 		traceln("transporter.ae.response.error:", err)


### PR DESCRIPTION
With this patch, it becomes possible to use the HTTPTransporter over custom transports, such as Unix sockets.

For a bit more context, I'm currently working on an application where speaking Raft over Unix sockets is necessary, and it's convenient to just keep using HTTP. It's possible (though a bit kludgey) to get http.Client to speak over Unix sockets. With this patch, I've successfully gotten Raft to run over them as well (happy to provide my client code if useful).
