### PR TITLE
Fix spelling errors in comments and strings.

### DIFF
--- a/log.go
+++ b/log.go
@@ -262,7 +262,7 @@ func (l *Log) getEntriesAfter(index uint64, maxLogEntriesPerRequest uint64) ([]*
 	entries := l.entries[index-l.startIndex:]
 	length := len(entries)
 
-	traceln("log.entriesAfter: startIndex:", l.startIndex, " lenght", len(l.entries))
+	traceln("log.entriesAfter: startIndex:", l.startIndex, " length", len(l.entries))
 
 	if uint64(length) < maxLogEntriesPerRequest {
 		// Determine the term at the given entry and return a subslice.
@@ -336,7 +336,7 @@ func (l *Log) setCommitIndex(index uint64) error {
 	// Do not allow previous indices to be committed again.
 
 	// This could happens, since the guarantee is that the new leader has up-to-dated
-	// log entires rather than has most up-to-dated committed index
+	// log entries rather than has most up-to-dated committed index
 
 	// For example, Leader 1 send log 80 to follower 2 and follower 3
 	// follower 2 and follow 3 all got the new entries and reply

--- a/peer.go
+++ b/peer.go
@@ -202,7 +202,7 @@ func (p *Peer) sendAppendEntriesRequest(req *AppendEntriesRequest) {
 		if resp.CommitIndex >= p.prevLogIndex {
 
 			// we may miss a response from peer
-			// so maybe the peer has commited the logs we sent
+			// so maybe the peer has committed the logs we sent
 			// but we did not receive the success reply and did not increase
 			// the prevLogIndex
 

--- a/server.go
+++ b/server.go
@@ -908,7 +908,7 @@ func (s *server) processAppendEntriesRequest(req *AppendEntriesRequest) (*Append
 		return newAppendEntriesResponse(s.currentTerm, false, s.log.currentIndex(), s.log.CommitIndex()), true
 	}
 
-	// once the server appended and commited all the log entries from the leader
+	// once the server appended and committed all the log entries from the leader
 
 	return newAppendEntriesResponse(s.currentTerm, true, s.log.currentIndex(), s.log.CommitIndex()), true
 }


### PR DESCRIPTION
I corrected the spelling in several comments and one string used for log entries. I didn't correct the spelling error mentioned in pull request #137.
