### PR TITLE
fix(log_entry.go) reports the right read size

### DIFF
--- a/log_entry.go
+++ b/log_entry.go
@@ -95,5 +95,5 @@ func (e *LogEntry) decode(r io.Reader) (int, error) {
 	e.CommandName = pb.GetCommandName()
 	e.Command = pb.Command
 
-	return length, nil
+	return length + 8 + 1, nil
 }


### PR DESCRIPTION
fix #158 
