### PR TITLE
fix(*.go): rename HeartbeatTimeout to HeartbeatInterval

### DIFF
--- a/event.go
+++ b/event.go
@@ -7,7 +7,7 @@ const (
 	AddPeerEventType      = "addPeer"
 	RemovePeerEventType   = "removePeer"
 
-	HeartbeatTimeoutEventType         = "heartbeatTimeout"
+	HeartbeatIntervalEventType        = "heartbeatInterval"
 	ElectionTimeoutThresholdEventType = "electionTimeoutThreshold"
 
 	HeartbeatEventType = "heartbeat"

--- a/http_transporter_test.go
+++ b/http_transporter_test.go
@@ -43,7 +43,7 @@ func runTestHttpServers(t *testing.T, servers *[]Server, transporter *HTTPTransp
 
 		// Create raft server.
 		server := newTestServer(fmt.Sprintf("localhost:%d", port), transporter)
-		server.SetHeartbeatTimeout(testHeartbeatTimeout)
+		server.SetHeartbeatInterval(testHeartbeatInterval)
 		server.SetElectionTimeout(testElectionTimeout)
 		server.Start()
 
@@ -74,7 +74,7 @@ func runTestHttpServers(t *testing.T, servers *[]Server, transporter *HTTPTransp
 	}
 
 	// Wait for configuration to propagate.
-	time.Sleep(testHeartbeatTimeout * 2)
+	time.Sleep(testHeartbeatInterval * 2)
 
 	// Execute all the callbacks at the same time.
 	for _i, _f := range callbacks {
@@ -101,7 +101,7 @@ func BenchmarkSpeed(b *testing.B) {
 
 		// Create raft server.
 		server := newTestServer(fmt.Sprintf("localhost:%d", port), transporter)
-		server.SetHeartbeatTimeout(testHeartbeatTimeout)
+		server.SetHeartbeatInterval(testHeartbeatInterval)
 		server.SetElectionTimeout(testElectionTimeout)
 		server.Start()
 
@@ -131,7 +131,7 @@ func BenchmarkSpeed(b *testing.B) {
 	c := make(chan bool)
 
 	// Wait for configuration to propagate.
-	time.Sleep(testHeartbeatTimeout * 2)
+	time.Sleep(testHeartbeatInterval * 2)
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {

--- a/peer.go
+++ b/peer.go
@@ -13,13 +13,13 @@ import (
 
 // A peer is a reference to another server involved in the consensus protocol.
 type Peer struct {
-	server           *server
-	Name             string `json:"name"`
-	ConnectionString string `json:"connectionString"`
-	prevLogIndex     uint64
-	mutex            sync.RWMutex
-	stopChan         chan bool
-	heartbeatTimeout time.Duration
+	server            *server
+	Name              string `json:"name"`
+	ConnectionString  string `json:"connectionString"`
+	prevLogIndex      uint64
+	mutex             sync.RWMutex
+	stopChan          chan bool
+	heartbeatInterval time.Duration
 }
 
 //------------------------------------------------------------------------------
@@ -29,12 +29,12 @@ type Peer struct {
 //------------------------------------------------------------------------------
 
 // Creates a new peer.
-func newPeer(server *server, name string, connectionString string, heartbeatTimeout time.Duration) *Peer {
+func newPeer(server *server, name string, connectionString string, heartbeatInterval time.Duration) *Peer {
 	return &Peer{
-		server:           server,
-		Name:             name,
-		ConnectionString: connectionString,
-		heartbeatTimeout: heartbeatTimeout,
+		server:            server,
+		Name:              name,
+		ConnectionString:  connectionString,
+		heartbeatInterval: heartbeatInterval,
 	}
 }
 
@@ -45,8 +45,8 @@ func newPeer(server *server, name string, connectionString string, heartbeatTime
 //------------------------------------------------------------------------------
 
 // Sets the heartbeat timeout.
-func (p *Peer) setHeartbeatTimeout(duration time.Duration) {
-	p.heartbeatTimeout = duration
+func (p *Peer) setHeartbeatInterval(duration time.Duration) {
+	p.heartbeatInterval = duration
 }
 
 //--------------------------------------
@@ -116,9 +116,9 @@ func (p *Peer) heartbeat(c chan bool) {
 
 	c <- true
 
-	ticker := time.Tick(p.heartbeatTimeout)
+	ticker := time.Tick(p.heartbeatInterval)
 
-	debugln("peer.heartbeat: ", p.Name, p.heartbeatTimeout)
+	debugln("peer.heartbeat: ", p.Name, p.heartbeatInterval)
 
 	for {
 		select {
@@ -170,7 +170,7 @@ func (p *Peer) sendAppendEntriesRequest(req *AppendEntriesRequest) {
 
 	resp := p.server.Transporter().SendAppendEntriesRequest(p.server, p, req)
 	if resp == nil {
-		p.server.DispatchEvent(newEvent(HeartbeatTimeoutEventType, p, nil))
+		p.server.DispatchEvent(newEvent(HeartbeatIntervalEventType, p, nil))
 		debugln("peer.append.timeout: ", p.server.Name(), "->", p.Name)
 		return
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -193,7 +193,7 @@ func TestServerPromote(t *testing.T) {
 func TestServerAppendEntries(t *testing.T) {
 	s := newTestServer("1", &testTransporter{})
 
-	s.SetHeartbeatTimeout(time.Second * 10)
+	s.SetHeartbeatInterval(time.Second * 10)
 	s.Start()
 	defer s.Stop()
 
@@ -393,14 +393,14 @@ func TestServerRecoverFromPreviousLogAndConf(t *testing.T) {
 
 		if name == "1" {
 			leader = s
-			s.SetHeartbeatTimeout(testHeartbeatTimeout)
+			s.SetHeartbeatInterval(testHeartbeatInterval)
 			s.Start()
-			time.Sleep(testHeartbeatTimeout)
+			time.Sleep(testHeartbeatInterval)
 		} else {
 			s.SetElectionTimeout(testElectionTimeout)
-			s.SetHeartbeatTimeout(testHeartbeatTimeout)
+			s.SetHeartbeatInterval(testHeartbeatInterval)
 			s.Start()
-			time.Sleep(testHeartbeatTimeout)
+			time.Sleep(testHeartbeatInterval)
 		}
 		if _, err := leader.Do(&DefaultJoinCommand{Name: name}); err != nil {
 			t.Fatalf("Unable to join server[%s]: %v", name, err)
@@ -415,7 +415,7 @@ func TestServerRecoverFromPreviousLogAndConf(t *testing.T) {
 		}
 	}
 
-	time.Sleep(2 * testHeartbeatTimeout)
+	time.Sleep(2 * testHeartbeatInterval)
 
 	for _, name := range names {
 		s := servers[name]
@@ -473,7 +473,7 @@ func TestServerSingleNode(t *testing.T) {
 
 	s.Start()
 
-	time.Sleep(testHeartbeatTimeout)
+	time.Sleep(testHeartbeatInterval)
 
 	// Join the server to itself.
 	if _, err := s.Do(&DefaultJoinCommand{Name: "1"}); err != nil {
@@ -573,14 +573,14 @@ func TestServerMultiNode(t *testing.T) {
 
 		if name == "1" {
 			leader = s
-			s.SetHeartbeatTimeout(testHeartbeatTimeout)
+			s.SetHeartbeatInterval(testHeartbeatInterval)
 			s.Start()
-			time.Sleep(testHeartbeatTimeout)
+			time.Sleep(testHeartbeatInterval)
 		} else {
 			s.SetElectionTimeout(testElectionTimeout)
-			s.SetHeartbeatTimeout(testHeartbeatTimeout)
+			s.SetHeartbeatInterval(testHeartbeatInterval)
 			s.Start()
-			time.Sleep(testHeartbeatTimeout)
+			time.Sleep(testHeartbeatInterval)
 		}
 		if _, err := leader.Do(&DefaultJoinCommand{Name: name}); err != nil {
 			t.Fatalf("Unable to join server[%s]: %v", name, err)

--- a/snapshot_recovery_response.go
+++ b/snapshot_recovery_response.go
@@ -40,7 +40,7 @@ func (req *SnapshotRecoveryResponse) Encode(w io.Writer) (int, error) {
 	return w.Write(p)
 }
 
-// Decodes the SnapshotRecoveryResponse from a buffer. 
+// Decodes the SnapshotRecoveryResponse from a buffer.
 func (req *SnapshotRecoveryResponse) Decode(r io.Reader) (int, error) {
 	data, err := ioutil.ReadAll(r)
 

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -9,7 +9,7 @@ import (
 
 // Ensure that a snapshot occurs when there are existing logs.
 func TestSnapshot(t *testing.T) {
-	runServerWithMockStateMachine(Leader, func (s Server, m *mock.Mock) {
+	runServerWithMockStateMachine(Leader, func(s Server, m *mock.Mock) {
 		m.On("Save").Return([]byte("foo"), nil)
 		m.On("Recovery", []byte("foo")).Return(nil)
 
@@ -36,7 +36,7 @@ func TestSnapshot(t *testing.T) {
 
 // Ensure that a snapshot request can be sent and received.
 func TestSnapshotRequest(t *testing.T) {
-	runServerWithMockStateMachine(Follower, func (s Server, m *mock.Mock) {
+	runServerWithMockStateMachine(Follower, func(s Server, m *mock.Mock) {
 		m.On("Recovery", []byte("bar")).Return(nil)
 
 		// Send snapshot request.
@@ -56,7 +56,7 @@ func TestSnapshotRequest(t *testing.T) {
 	})
 }
 
-func runServerWithMockStateMachine(state string, fn func (s Server, m *mock.Mock)) {
+func runServerWithMockStateMachine(state string, fn func(s Server, m *mock.Mock)) {
 	var m mockStateMachine
 	s := newTestServer("1", &testTransporter{})
 	s.(*server).stateMachine = &m

--- a/statemachine_test.go
+++ b/statemachine_test.go
@@ -13,7 +13,7 @@ func (m *mockStateMachine) Save() ([]byte, error) {
 	return args.Get(0).([]byte), args.Error(1)
 }
 
-func (m *mockStateMachine) Recovery(b []byte) (error) {
+func (m *mockStateMachine) Recovery(b []byte) error {
 	args := m.Called(b)
 	return args.Error(0)
 }

--- a/test.go
+++ b/test.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	testHeartbeatTimeout = 50 * time.Millisecond
-	testElectionTimeout  = 200 * time.Millisecond
+	testHeartbeatInterval = 50 * time.Millisecond
+	testElectionTimeout   = 200 * time.Millisecond
 )
 
 const (
@@ -115,7 +115,7 @@ func newTestCluster(names []string, transporter Transporter, lookup map[string]S
 		lookup[name] = server
 	}
 	for _, server := range servers {
-		server.SetHeartbeatTimeout(testHeartbeatTimeout)
+		server.SetHeartbeatInterval(testHeartbeatInterval)
 		server.Start()
 		for _, peer := range servers {
 			server.AddPeer(peer.Name(), "")


### PR DESCRIPTION
While re-reading the etcd tuning guide I realized that perhaps it is a
bit of a misnomer to call this a "Timeout" since unlike the "Election
Timeout" there is no immediate consequence of it being missed.

Perhaps naming it interval would be better?
