### PR TITLE
Add EventDispatcher.RemoveEventListener().

### DIFF
--- a/event_dispatcher.go
+++ b/event_dispatcher.go
@@ -1,6 +1,7 @@
 package raft
 
 import (
+	"reflect"
 	"sync"
 )
 
@@ -31,6 +32,23 @@ func (d *eventDispatcher) AddEventListener(typ string, listener EventListener) {
 	d.Lock()
 	defer d.Unlock()
 	d.listeners[typ] = append(d.listeners[typ], listener)
+}
+
+// RemoveEventListener removes a listener function for a given event type.
+func (d *eventDispatcher) RemoveEventListener(typ string, listener EventListener) {
+	d.Lock()
+	defer d.Unlock()
+
+	// Grab a reference to the function pointer once.
+	ptr := reflect.ValueOf(listener).Pointer()
+
+	// Find listener by pointer and remove it.
+	listeners := d.listeners[typ]
+	for i, l := range listeners {
+		if reflect.ValueOf(l).Pointer() == ptr {
+			d.listeners[typ] = append(listeners[:i], listeners[i+1:]...)
+		}
+	}
 }
 
 // DispatchEvent dispatches an event.

--- a/event_dispatcher_test.go
+++ b/event_dispatcher_test.go
@@ -23,6 +23,25 @@ func TestDispatchEvent(t *testing.T) {
 	assert.Equal(t, 11, count)
 }
 
+// Ensure that we can add and remove a listener.
+func TestRemoveEventListener(t *testing.T) {
+	var count int
+	f0 := func(e Event) {
+		count += 1
+	}
+	f1 := func(e Event) {
+		count += 10
+	}
+
+	dispatcher := newEventDispatcher(nil)
+	dispatcher.AddEventListener("foo", f0)
+	dispatcher.AddEventListener("foo", f1)
+	dispatcher.DispatchEvent(&event{typ: "foo"})
+	dispatcher.RemoveEventListener("foo", f0)
+	dispatcher.DispatchEvent(&event{typ: "foo"})
+	assert.Equal(t, 21, count)
+}
+
 // Ensure that event is properly passed to listener.
 func TestEventListener(t *testing.T) {
 	dispatcher := newEventDispatcher("X")


### PR DESCRIPTION
This pull request adds a `RemoveEventListener()` function to `EventDispatcher`. I didn't add this originally because you can't check function equality with `==` but apparently it works if you use the `reflect` package.
