### PR TITLE
refactor(server.go) change setCurrentTerm to updateCurrentTerm

### DIFF
--- a/server.go
+++ b/server.go
@@ -492,13 +492,11 @@ func (s *server) Running() bool {
 // updates the current term for the server. This is only used when a larger
 // external term is found.
 func (s *server) updateCurrentTerm(term uint64, leaderName string) {
+	_assert(term > s.currentTerm,
+		"upadteCurrentTerm: update is called when term is not larger than currentTerm")
+
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-
-	if term <= s.currentTerm {
-		panic("updteCurrentTerm: update is called when term is not larger than currentTerm")
-	}
-
 	// Store previous values temporarily.
 	prevTerm := s.currentTerm
 	prevLeader := s.leader
@@ -877,10 +875,7 @@ func (s *server) processAppendEntriesRequest(req *AppendEntriesRequest) (*Append
 	}
 
 	if req.Term == s.currentTerm {
-		if s.state == Leader {
-			msg := fmt.Sprintf("leader.elected.at.same.term.%d\n", s.currentTerm)
-			panic(msg)
-		}
+		_assert(s.state != Leader, "leader.elected.at.same.term.%d\n", s.currentTerm)
 		// change state to follower
 		s.state = Follower
 		// discover new leader when candidate

--- a/util.go
+++ b/util.go
@@ -1,6 +1,7 @@
 package raft
 
 import (
+	"fmt"
 	"io"
 	"math/rand"
 	"os"
@@ -48,4 +49,13 @@ func afterBetween(min time.Duration, max time.Duration) <-chan time.Time {
 		d += time.Duration(rand.Int63n(int64(delta)))
 	}
 	return time.After(d)
+}
+
+// TODO(xiangli): Remove assertions when we reach version 1.0
+
+// _assert will panic with a given formatted message if the given condition is false.
+func _assert(condition bool, msg string, v ...interface{}) {
+	if !condition {
+		panic(fmt.Sprintf("assertion failed: "+msg, v...))
+	}
 }


### PR DESCRIPTION
process functions should always compare the term
simplify the logic of updateCurrentTerm
remove unnecessary setState
