### PR TITLE
Change LogEntry.Decode() to use io.ReadFull()

### DIFF
--- a/log_entry.go
+++ b/log_entry.go
@@ -91,7 +91,7 @@ func (e *LogEntry) Decode(r io.Reader) (int, error) {
 	}
 
 	data := make([]byte, length)
-	_, err = r.Read(data)
+	_, err = io.ReadFull(r, data)
 
 	if err != nil {
 		return -1, err


### PR DESCRIPTION
Per @ayende, a log entry can be partially read which could cause corruption or data loss. This changes the read to ensure that the expected number of bytes are read.

Fix: #191

/cc @xiangli-cmu
