### PR TITLE
Use exponential backoff for failed peer heartbeats.

### DIFF
--- a/peer_test.go
+++ b/peer_test.go
@@ -1,0 +1,40 @@
+package raft
+
+import (
+	"testing"
+	"time"
+)
+
+func TestHeartbeatDuration(t *testing.T) {
+	heartbeatInterval := time.Duration(20)
+	p := newPeer(nil, "testpeer", "testpeer", heartbeatInterval)
+	if p.failedHeartbeats != 0 {
+		t.Error("Failed heartbeat counter's default is not 0.")
+	}
+
+	if p.heartbeatDuration() != heartbeatInterval {
+		t.Errorf("Unexpected heartbeat duration. Expected %d, got %d", heartbeatInterval, p.heartbeatDuration())
+	}
+
+	p.backoffHeartbeat()
+
+	if p.failedHeartbeats != 1 {
+		t.Errorf("Failed heartbeat counter did not increment. Expected %d, got %d", 1, p.failedHeartbeats)
+	}
+
+	firstBackoff := time.Duration(heartbeatInterval * 2)
+	if p.heartbeatDuration() != firstBackoff {
+		t.Errorf("Unexpected heartbeat duration. Expected %d, got %d", firstBackoff, p.heartbeatDuration())
+	}
+
+	p.backoffHeartbeat()
+	secondBackoff := time.Duration(heartbeatInterval * 4)
+	if p.heartbeatDuration() != secondBackoff {
+		t.Errorf("Unexpected heartbeat duration. Expected %d, got %d", secondBackoff, p.heartbeatDuration())
+	}
+
+	p.resetHeartbeatInterval()
+	if p.heartbeatDuration() != heartbeatInterval {
+		t.Errorf("Unexpected heartbeat interval. Expected %d, got %d", heartbeatInterval, p.heartbeatDuration())
+	}
+}


### PR DESCRIPTION
Noticed @xiangli-cmu mention exponential back-off for peer heartbeats in https://github.com/coreos/etcd/issues/595 and thought it might make a good first attempt to contribute.

Feedback would be greatly appreciated.
