### PR TITLE
feat(server): add UpdatePeer

### DIFF
--- a/server.go
+++ b/server.go
@@ -1057,6 +1057,14 @@ func (s *server) AddPeer(name string, connectiongString string) error {
 	return nil
 }
 
+// Updates a peer from the server.
+func (s *server) UpdatePeer(name string) error {
+	s.debugln("server.peer.update: ", name, len(s.peers))
+	// Write the configuration to file.
+	s.writeConf()
+	return nil
+}
+
 // Removes a peer from the server.
 func (s *server) RemovePeer(name string) error {
 	s.debugln("server.peer.remove: ", name, len(s.peers))


### PR DESCRIPTION
The function is used to update peer info and rewrite conf file.

This is caused by coreos/etcd#639
I want to update the peer information to adopt new IP when joining with different IP.
Then I found it cannot load these information when restart because `commitIndex` in `conf` decides how many commits raft will load from the log when start, and I didn't update it.
So I need to add this function to update `conf` file to load correct information.
