### PR TITLE
feat(server): add FlushCommitIndex

### DIFF
--- a/server.go
+++ b/server.go
@@ -101,6 +101,7 @@ type Server interface {
 	TakeSnapshot() error
 	LoadSnapshot() error
 	AddEventListener(string, EventListener)
+	FlushCommitIndex()
 }
 
 type server struct {


### PR DESCRIPTION
Sometimes etcd needs raft to replay more when restart.
This function could be used to set it.
