### PR TITLE
fix(server.Init) Fix wrong error reporting

### DIFF
--- a/server.go
+++ b/server.go
@@ -474,7 +474,8 @@ func (s *server) Init() error {
 	}
 
 	// Create snapshot directory if it does not exist
-	if err := os.Mkdir(path.Join(s.path, "snapshot"), 0700); err != nil {
+	err := os.Mkdir(path.Join(s.path, "snapshot"), 0700)
+	if err != nil && os.IsNotExist(err) {
 		s.debugln("raft: Snapshot dir error: ", err)
 		return fmt.Errorf("raft: Initialization error: %s", err)
 	}


### PR DESCRIPTION
We should only report error if the snapshot path is not exist and we cannot create a new one.
