### PR TITLE
util: Handle all errors in writeFileSync

### DIFF
--- a/util.go
+++ b/util.go
@@ -25,15 +25,16 @@ func writeFileSynced(filename string, data []byte, perm os.FileMode) error {
 	if err != nil {
 		return err
 	}
+	defer f.Close() // Idempotent
 
 	n, err := f.Write(data)
-	if n < len(data) {
-		f.Close()
+	if err == nil && n < len(data) {
 		return io.ErrShortWrite
+	} else if err != nil {
+		return err
 	}
 
-	err = f.Sync()
-	if err != nil {
+	if err = f.Sync(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Before this patch, errors returned by `f.Write` would be swallowed and
replaced by `io.ErrShortWrite` if the number of bytes written was less than the
number of bytes to be written.

etcd was panicking on startup because it had no space to write conf.tmp to its
data directory and the panic string was "short write" which was not very
informative of the real problem.

After applying this patch, we got a nice error message in our panic:
"panic: write /data/etcd/conf.tmp: no space left on device"
