### PR TITLE
feat(log): set NOCOW flag when using btrfs

### DIFF
--- a/log.go
+++ b/log.go
@@ -146,12 +146,16 @@ func (l *Log) open(path string) error {
 		// if the log file does not exist before
 		// we create the log file and set commitIndex to 0
 		if os.IsNotExist(err) {
-			l.file, err = os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0600)
 			debugln("log.open.create ", path)
-			if err == nil {
-				l.initialized = true
+			l.file, err = os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0600)
+			if err != nil {
+				return err
 			}
-			return err
+			if isBtrfs(l.file.Fd()) {
+				setNOCOW(l.file.Fd())
+			}
+			l.initialized = true
+			return nil
 		}
 		return err
 	}

--- a/util_linux.go
+++ b/util_linux.go
@@ -1,0 +1,51 @@
+// +build linux
+// +build cgo
+
+package raft
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+/*
+#include <sys/ioctl.h>
+#include <linux/fs.h>
+#include <linux/magic.h>
+
+int myioctl(int d, unsigned long request, int *attr) {
+	return ioctl(d, request, attr);
+}
+*/
+import "C"
+
+// isBtrfs checks whether the file is in btrfs
+func isBtrfs(fd uintptr) bool {
+	var buf syscall.Statfs_t
+	if err := syscall.Fstatfs(int(fd), &buf); err != nil {
+		debugln("syscall.statfs.fail ", err)
+		return false
+	}
+	traceln("syscall.statfs.type ", buf.Type)
+	// #define BTRFS_SUPER_MAGIC       0x9123683E
+	if buf.Type != C.BTRFS_SUPER_MAGIC {
+		return false
+	}
+	debugln("syscall.statfs.is.btrfs")
+	return true
+}
+
+// setNOCOW sets NOCOW flag for the file
+func setNOCOW(fd uintptr) {
+	var attr int
+	if C.myioctl(C.int(fd), C.FS_IOC_GETFLAGS, (*C.int)(unsafe.Pointer(&attr))) != 0 {
+		debugln("ioctl.get.flags.fail")
+		return
+	}
+	attr |= C.FS_NOCOW_FL
+	if C.myioctl(C.int(fd), C.FS_IOC_SETFLAGS, (*C.int)(unsafe.Pointer(&attr))) != 0 {
+		debugln("ioctl.set.flags.fail")
+		return
+	}
+	debugln("ioctl.set.nocow.succeed")
+}

--- a/util_linux_test.go
+++ b/util_linux_test.go
@@ -1,0 +1,35 @@
+// +build linux
+// +build cgo
+
+package raft
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestSetNOCOW(t *testing.T) {
+	f, err := ioutil.TempFile("/", "test")
+	if err != nil {
+		t.Fatal("Failed creating tempfile")
+	}
+	defer func() {
+		f.Close()
+		os.Remove(f.Name())
+	}()
+
+	if isBtrfs(f.Fd()) {
+		setNOCOW(f.Fd())
+		cmd := exec.Command("lsattr", f.Name())
+		out, err := cmd.Output()
+		if err != nil {
+			t.Fatal("Failed executing lsattr")
+		}
+		if !strings.Contains(string(out), "---------------C") {
+			t.Fatal("Failed setting NOCOW:\n", out)
+		}
+	}
+}

--- a/util_stubs.go
+++ b/util_stubs.go
@@ -1,0 +1,10 @@
+// +build !linux
+
+package raft
+
+func isBtrfs(fd uintptr) bool {
+	return false
+}
+
+func setNOCOW(fd uintptr) {
+}


### PR DESCRIPTION
fsync is expensive without doing this.
It is only applied to 'log' file now.

If this patch is merged, raft will need `gcc` assistance for compile.

coreos/etcd#684
