### PR TITLE
fix(server.go) check server state before send event to channel

### DIFF
--- a/server.go
+++ b/server.go
@@ -613,6 +613,10 @@ func (s *server) loop() {
 // Sends an event to the event loop to be processed. The function will wait
 // until the event is actually processed before returning.
 func (s *server) send(value interface{}) (interface{}, error) {
+	if !s.Running() {
+		return nil, StopError
+	}
+
 	event := &ev{target: value, c: make(chan error, 1)}
 	select {
 	case s.c <- event:
@@ -628,6 +632,10 @@ func (s *server) send(value interface{}) (interface{}, error) {
 }
 
 func (s *server) sendAsync(value interface{}) {
+	if !s.Running() {
+		return
+	}
+
 	event := &ev{target: value, c: make(chan error, 1)}
 	// try a non-blocking send first
 	// in most cases, this should not be blocking


### PR DESCRIPTION
This commit fixs a data race between server.Start() and server.send(). Before this commit, server send might receive on a uninitialized stopped channel. To fix this, we initialize the channel before we change the server state to a running state. Then we check the state before receive on the stopped channel.
