### PR TITLE
fix(server.go) fix data race between func LogEntries and func appendEntry

### DIFF
--- a/server.go
+++ b/server.go
@@ -334,6 +334,8 @@ func (s *server) IsLogEmpty() bool {
 
 // A list of all the log entries. This should only be used for debugging purposes.
 func (s *server) LogEntries() []*LogEntry {
+	s.log.mutex.RLock()
+	defer s.log.mutex.RUnlock()
 	return s.log.entries
 }
 


### PR DESCRIPTION
The append function in appendEntry might change the value of the slice pointer when it wants to grow the capacity of the slice. We are not protecting the content of the slice, since the LogEntries func is just used for internal testing. The main reason of this pull request is to make the race detector happy during the testing.
