### PR TITLE
Pad snapshot filenames with 0s

### DIFF
--- a/server.go
+++ b/server.go
@@ -1255,7 +1255,7 @@ func (s *server) saveSnapshot() error {
 
 // Retrieves the log path for the server.
 func (s *server) SnapshotPath(lastIndex uint64, lastTerm uint64) string {
-	return path.Join(s.path, "snapshot", fmt.Sprintf("%v_%v.ss", lastTerm, lastIndex))
+	return path.Join(s.path, "snapshot", fmt.Sprintf("%024v_%024v.ss", lastTerm, lastIndex))
 }
 
 func (s *server) RequestSnapshot(req *SnapshotRequest) *SnapshotResponse {


### PR DESCRIPTION
Allowing up to 24 0s is sufficient for a 64-bit unsigned int.
