### PR TITLE
Command#Apply is passed inconsistent context information.

### DIFF
--- a/server.go
+++ b/server.go
@@ -199,7 +199,7 @@ func NewServer(name string, path string, transporter Transporter, stateMachine S
 			return c.Apply(&context{
 				server:       s,
 				currentTerm:  s.currentTerm,
-				currentIndex: s.log.internalCurrentIndex(),
+				currentIndex: e.Index(),
 				commitIndex:  s.log.commitIndex,
 			})
 		case deprecatedCommandApply:

--- a/test.go
+++ b/test.go
@@ -19,6 +19,7 @@ const (
 func init() {
 	RegisterCommand(&testCommand1{})
 	RegisterCommand(&testCommand2{})
+	RegisterCommand(&testApplyCommand{})
 }
 
 //------------------------------------------------------------------------------
@@ -193,5 +194,30 @@ func (c *testCommand2) CommandName() string {
 }
 
 func (c *testCommand2) Apply(server Server) (interface{}, error) {
+	return nil, nil
+}
+
+//-----------------------------------------------
+// ApplyCommand - testing passed content to Apply
+//-----------------------------------------------
+
+var appliedContexts []Context
+
+type testApplyCommand struct {
+	Val string `json:"val"`
+	I   int    `json:"i"`
+}
+
+func (c *testApplyCommand) CommandName() string {
+	return "cmd_apply"
+}
+
+func (c *testApplyCommand) Apply(context Context) (interface{}, error) {
+	if appliedContexts == nil {
+		appliedContexts = make([]Context, 0)
+	}
+
+	appliedContexts = append(appliedContexts, context)
+
 	return nil, nil
 }


### PR DESCRIPTION
Hey all,

I'm using raft for a project, and using `context.CurrentIndex()` in my command's `Apply` function for some bookkeeping.

I noticed, in different circumstances, the `context.CurrentIndex()` is inconsistent.  For instance, committing 3 entries, in succession against a new 1-node cluster, results in the following contexts passed to the `Apply` function:

```
Term: 0 CurrentIndex: 3 CommitIndex: 3
Term: 0 CurrentIndex: 4 CommitIndex: 4
Term: 0 CurrentIndex: 5 CommitIndex: 5
```

Killing and restarting the node will force it to recover from the log. While recovering, we receive the following contexts as the node replays the committed entries:

```
Term: 0 CurrentIndex: 5 CommitIndex: 3
Term: 0 CurrentIndex: 5 CommitIndex: 4
Term: 0 CurrentIndex: 5 CommitIndex: 5
```

This is due to how the `internalCurrentIndex` log method is computed.

I've added a failing test, and adjusted the code to always return the index of the entry for `context.CurrentIndex()` (which is the current index we're applying to the state machine).

Let me know if anything here is unclear, or if I've misunderstood the meaning of `context.CurrentIndex()`.
