### PR TITLE
README: clarify etcd's use of raft

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ go-raft is under the MIT license.
 
 These projects are built on go-raft:
 
-- [coreos/etcd](https://github.com/coreos/etcd) - A highly-available key value store for shared configuration and service discovery.
+- [coreos/etcd 0.4.* and older](https://github.com/coreos/etcd) - A highly-available key value store for shared configuration and service discovery. Note: etcd from v2.0.0 onward has since started using a [new raft implementation](godoc.org/github.com/coreos/etcd/raft).
 - [goraft/raftd](https://github.com/goraft/raftd) - A reference implementation for using the go-raft library for distributed consensus.
 - [skynetservices/skydns](https://github.com/skynetservices/skydns) - DNS for skynet or any other service discovery.
 - [influxdb/influxdb](https://github.com/influxdb/influxdb) - An open-source, distributed, time series, events, and metrics database.


### PR DESCRIPTION
etcd has since started using a new raft implementation that more cleanly
separates the state machine from the log and RPC layer. Let people know
about this change.
