### PR TITLE
Fix(server): Clear Server.snapshot after a snapshot fails to save

### DIFF
--- a/server.go
+++ b/server.go
@@ -1237,6 +1237,7 @@ func (s *server) saveSnapshot() error {
 
 	// Write snapshot to disk.
 	if err := s.pendingSnapshot.save(); err != nil {
+		s.pendingSnapshot = nil
 		return err
 	}
 


### PR DESCRIPTION
Without this change, after one snapshot fails to save, all future calls to TakeSnapshot ()fail with "Snapshot: Last snapshot is not finished."
